### PR TITLE
Add custom Tight ID selection at the nanoAOD level

### DIFF
--- a/BParkingNano/plugins/MuonTriggerSelector.cc
+++ b/BParkingNano/plugins/MuonTriggerSelector.cc
@@ -31,6 +31,8 @@
 #include <TLorentzVector.h>
 #include "helper.h"
 
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
 using namespace std;
 
 constexpr bool debug = false; //false;
@@ -61,6 +63,7 @@ private:
 
     const double ptMin_;          // min pT in all muons for B candidates
     const double absEtaMax_;      //max eta ""
+    const StringCutObjectSelector<pat::Muon> muon_selection_; // cut on muon
     const bool softMuonsOnly_;    //cuts muons without soft ID
     std::vector<std::string> HLTPaths_;
 //    std::vector<std::string> L1Seeds_;
@@ -76,7 +79,9 @@ MuonTriggerSelector::MuonTriggerSelector(const edm::ParameterSet &iConfig):
   maxdR_(iConfig.getParameter<double>("maxdR_matching")),
   dzTrg_cleaning_(iConfig.getParameter<double>("dzForCleaning_wrtTrgMuon")),
   ptMin_(iConfig.getParameter<double>("ptMin")),
-  absEtaMax_(iConfig.getParameter<double>("absEtaMax")), 
+  absEtaMax_(iConfig.getParameter<double>("absEtaMax")),
+  muon_selection_(iConfig.getParameter<std::string>("muSelection")),
+
   softMuonsOnly_(iConfig.getParameter<bool>("softMuonsOnly")),   /////////Comma
   HLTPaths_(iConfig.getParameter<std::vector<std::string>>("HLTPaths"))//,   //////////Comma
 //  L1Seeds_(iConfig.getParameter<std::vector<std::string>>("L1seeds"))
@@ -243,6 +248,8 @@ void MuonTriggerSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSe
         unsigned int iMuo(&muon - &(muons->at(0)) );
         if(muon.pt()<ptMin_) continue;
         if(fabs(muon.eta())>absEtaMax_) continue;
+        if(!muon_selection_(muon)) continue;
+        if(!muon_selection_(muon)) std::cout <<"AL: muon is rejected" << endl;
         if(muon.isLooseMuon()){loose_id[iMuo] = 1;}
         bool SkipMuon=true;
         if(dzTrg_cleaning_<0) SkipMuon=false;

--- a/BParkingNano/python/muonsBPark_cff.py
+++ b/BParkingNano/python/muonsBPark_cff.py
@@ -19,6 +19,7 @@ muonTrgSelector = cms.EDProducer("MuonTriggerSelector",
 
                                  ptMin = cms.double(0.5),
                                  absEtaMax = cms.double(2.4),
+                                 muSelection = cms.string('isGlobalMuon && isPFMuon && globalTrack.normalizedChi2 < 10 && globalTrack.hitPattern.numberOfValidMuonHits > 0 && numberOfMatchedStations > 1 && innerTrack.hitPattern.numberOfValidPixelHits > 0 && innerTrack.hitPattern.trackerLayersWithMeasurement > 5'),
                                  # keeps only muons with at soft Quality flag
                                  softMuonsOnly = cms.bool(False),
                                  HLTPaths=cms.vstring(Path)#, ### comma to the softMuonsOnly
@@ -27,10 +28,9 @@ muonTrgSelector = cms.EDProducer("MuonTriggerSelector",
 #cuts minimun number in B both mu and e, min number of trg, dz muon, dz and dr track, 
 countTrgMuons = cms.EDFilter("PATCandViewCountFilter",
     minNumber = cms.uint32(1),
-    maxNumber = cms.uint32(999999),
+    maxNumber = cms.uint32(99999999),
     src = cms.InputTag("muonTrgSelector", "trgMuons")
 )
-
 
 muonBParkTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     src = cms.InputTag("muonTrgSelector:SelectedMuons"),
@@ -54,8 +54,13 @@ muonBParkTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         ip3d = Var("abs(dB('PV3D'))",float,doc="3D impact parameter wrt first PV, in cm",precision=10),
         sip3d = Var("abs(dB('PV3D')/edB('PV3D'))",float,doc="3D impact parameter significance wrt first PV",precision=10),
 #        segmentComp   = Var("segmentCompatibility()", float, doc = "muon segment compatibility", precision=14), # keep higher precision since people have cuts with 3 digits on this
-#        nStations = Var("numberOfMatchedStations", int, doc = "number of matched stations with default arbitration (segment & track)"),
-        #nTrackerLayers = Var("innerTrack().hitPattern().trackerLayersWithMeasurement()", int, doc = "number of layers in the tracker"),
+        nStations = Var("numberOfMatchedStations", int, doc = "number of matched stations with default arbitration (segment & track)"),
+       # normChi2 = Var("globalTrack()->normalizedChi2()", float, doc = "Custom Muon Tight ID"),
+        #normChi2 = Var("normChi2()", float, doc = "Custom Muon Tight ID"),
+      #  nValidMuonHits = Var("globalTrack().hitPattern().numberOfValidHits()", float, doc = "Custom Muon Tight ID"),
+      #  nValidPixelHits = Var("innerTrack().hitPattern().numberOfValidPixelHits()", float, doc = "Custom Muon Tight ID"),
+#        nTrackerLayers = Var("innerTrack().hitPattern().trackerLayersWithMeasurement()", int, doc = "number of layers in the tracker"),
+#        nTrackerLayers = Var("innerTrack().hitPattern().trackerLayersWithMeasurement()", int, doc = "number of layers in the tracker"),
 #        pfRelIso03_chg = Var("pfIsolationR03().sumChargedHadronPt/pt",float,doc="PF relative isolation dR=0.3, charged component"),
         pfRelIso03_all = Var("(pfIsolationR03().sumChargedHadronPt + max(pfIsolationR03().sumNeutralHadronEt + pfIsolationR03().sumPhotonEt - pfIsolationR03().sumPUPt/2,0.0))/pt",float,doc="PF relative isolation dR=0.3, total (deltaBeta corrections)"),
         pfRelIso04_all = Var("(pfIsolationR04().sumChargedHadronPt + max(pfIsolationR04().sumNeutralHadronEt + pfIsolationR04().sumPhotonEt - pfIsolationR04().sumPUPt/2,0.0))/pt",float,doc="PF relative isolation dR=0.4, total (deltaBeta corrections)"),


### PR DESCRIPTION
Add custom Tight ID selection at the nanoAOD level to enhance number of signal events